### PR TITLE
[feat] Add a 'Max Gap' setting to Nearby window.

### DIFF
--- a/pages/nearby-settings.html
+++ b/pages/nearby-settings.html
@@ -106,6 +106,10 @@
                     <key>Refresh interval:</key>
                     <input type="number" min="0" step="1" name="refreshInterval"/> <small>(seconds)</small>
                 </label>
+                <label title="Only show riders with a gap equal to or less than this. Blank or 0 to show all (default).">
+                    <key>Max gap:</key>
+                    <input type="number" min="0" step="1" name="maxGap"/> <small>(seconds)</small>
+                </label>
                 <label title="Keep the athlete being watched scrolled into view except when you manually scroll out of range">
                     <key>Auto scroll athlete:</key>
                     <input type="checkbox" name="autoscroll"/>

--- a/pages/src/nearby.mjs
+++ b/pages/src/nearby.mjs
@@ -464,6 +464,7 @@ export async function main() {
     common.initNationFlags();  // bg okay
     let onlyMarked = common.settingsStore.get('onlyMarked');
     let onlySameCategory= common.settingsStore.get('onlySameCategory');
+    let maxGap = common.settingsStore.get('maxGap');
     let refresh;
     const setRefresh = () => {
         refresh = (common.settingsStore.get('refreshInterval') || 0) * 1000 - 100; // within 100ms is fine.
@@ -490,6 +491,9 @@ export async function main() {
         }
         if (changed.has('onlySameCategory')) {
             onlySameCategory = changed.get('onlySameCategory');
+        }
+        if (changed.has('maxGap')) {
+            maxGap = changed.get('maxGap');
         }
         setBackground();
         render();
@@ -579,6 +583,9 @@ export async function main() {
             if (sgid) {
                 data = data.filter(x => x.state.eventSubgroupId === sgid);
             }
+        }
+        if (maxGap) {
+            data = data.filter(x => Math.abs(x.gap) <= maxGap);
         }
         nearbyData = data;
         const elapsed = Date.now() - lastRefresh;


### PR DESCRIPTION
Adding a 'Max Gap' setting to Nearby window to filter nearby athletes to only those within a certain time gap.
Useful for cutting down some of the clutter/churn of the Nearby window to just the riders immediately in your "group".