### PR TITLE
Remove tooltip on gauge type

### DIFF
--- a/pages/src/gauge.mjs
+++ b/pages/src/gauge.mjs
@@ -215,7 +215,6 @@ export function main() {
         gauge.setOption({
             animationDurationUpdate: Math.max(200, Math.min(settings.refreshInterval * 1000, 1000)),
             animationEasingUpdate: 'linear',
-            tooltip: undefined,
             visualMap: config.visualMap,
             graphic: [{
                 elements: [{

--- a/pages/src/gauge.mjs
+++ b/pages/src/gauge.mjs
@@ -215,7 +215,7 @@ export function main() {
         gauge.setOption({
             animationDurationUpdate: Math.max(200, Math.min(settings.refreshInterval * 1000, 1000)),
             animationEasingUpdate: 'linear',
-            tooltip: {},
+            tooltip: undefined,
             visualMap: config.visualMap,
             graphic: [{
                 elements: [{


### PR DESCRIPTION
I get this tooltip sometimes, even though not hovering on it. 
This change removes it.

![tooltip](https://github.com/SauceLLC/sauce4zwift/assets/2890010/8a771c6d-4045-4c4e-96fd-59e788c78b5e)
