### PR TITLE
Add route to events list

### DIFF
--- a/pages/templates/events/list.html.tpl
+++ b/pages/templates/events/list.html.tpl
@@ -4,6 +4,7 @@
             <th>Start</th>
             <th>Type</th>
             <th class="name">Name</th>
+            <th>Route</th>
             <th>Length</th>
             <th title="Climbing elevation gain"><ms>landscape</ms></th>
             <th>Groups</th>

--- a/pages/templates/events/summary.html.tpl
+++ b/pages/templates/events/summary.html.tpl
@@ -19,6 +19,13 @@
         {-event.sport === 'running' ? '<ms large title="Run">directions_run</ms>' : ''-}
     </td>
     <td class="name">{{event.name}}</td>
+    <td><% if (event.sameRoute) { %>
+            {{event.route.name}}
+        <% } else { %>
+            <% const uRoutes = new Set(event.eventSubgroups ? event.eventSubgroups.map(x => x.route.name) : [event.route.name]); %>
+            {{Array.from(uRoutes).join(', ')}}
+        <% } %>
+    </td>
     <% if (event.durationInSeconds) { %>
         <td>{-humanDuration(event.durationInSeconds, {suffix: true, html: true})-}</td>
     <% } else { %>


### PR DESCRIPTION
Add the event route(s) to events summary page.
![image](https://github.com/SauceLLC/sauce4zwift/assets/6671862/d67eec37-2ffd-4ce9-877b-812372dbb281)
