### PR TITLE
Player state fields 44, 45, 46, 47, 48

### DIFF
--- a/src/zwift.proto
+++ b/src/zwift.proto
@@ -39,11 +39,11 @@ message PlayerState {
     int32 pacerBotGroupSize = 40;
     bool activeSteer = 41;
     bool portal = 43;
-    int32 _f44 = 44;
-    int32 _f45 = 45;
-    int32 _f46 = 46; // 2?
-    int32 _f47 = 47; // 2?
-    int32 _f48 = 48;
+    int32 portalGradientScale = 44; // 0 = 50%, 1 = 75%, 2 = 100%, 3 = 125%
+    int32 portalElevationScale = 45; // 50, 75, 100 or 125
+    int32 boostPad = 46;
+    int32 hazardPad = 47;
+    int32 timeBonus = 48;
     int32 rideonBomb = 49; // always seems to be x5 with value of 9
 }
 


### PR DESCRIPTION
44 / portalGradientScale could probably be used to correct the grade shown in Sauce when in the climb portal at something other than 100%