### PR TITLE
Settings - zwift logins as sensitive data

### DIFF
--- a/pages/overview-settings.html
+++ b/pages/overview-settings.html
@@ -9,6 +9,7 @@
         <title>Settings - Sauce for Zwift™</title>
 
         <script src="./src/preloads.js"></script>
+        <script src="./src/overview-settings.js"></script>
 
         <link rel="preload" href="/pages/fonts/PermanentMarker.woff2?v=1" as="font"
               type="font/woff2" crossorigin="anonymous">
@@ -73,14 +74,14 @@
 
                 <label class="login" title="This should be the account you use for the real Zwift game">
                     <key>Main Zwift Login:</key>
-                    <span class="display-field" name="mainZwiftLogin">-</span>
+                    <span class="display-field sensitive-data" name="mainZwiftLogin">-</span>
                     <div title="You will be asked to login again on restart."
                          class="std button xs" data-action="logout-zwift" data-id="main">Logout</div>
                     <span class="restart-required"></span>
                 </label>
                 <label class="login" title="This should be a UNIQUE second account only used by Sauce">
                     <key>Monitor Zwift Login:</key>
-                    <span class="display-field" name="monitorZwiftLogin">-</span>
+                    <span class="display-field sensitive-data" name="monitorZwiftLogin">-</span>
                     <div title="You will be asked to login again on restart."
                          class="std button xs" data-action="logout-zwift" data-id="monitor">Logout</div>
                     <span class="restart-required"></span>

--- a/pages/scss/overview-settings.scss
+++ b/pages/scss/overview-settings.scss
@@ -614,3 +614,7 @@ img.logo {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.sensitive-data {
+    -webkit-text-security: disc !important;
+}

--- a/pages/src/overview-settings.js
+++ b/pages/src/overview-settings.js
@@ -1,0 +1,9 @@
+document.addEventListener("DOMContentLoaded", (event) => {
+    const sensitiveFields = document.querySelectorAll('label.login span.sensitive-data');
+
+    sensitiveFields.forEach(field => {
+        field.addEventListener('click', function(){
+            field.classList.remove("sensitive-data");
+        });
+    });
+});


### PR DESCRIPTION
Is shows the current Zwift login email addresses masked, showing the value when clicking on it. Useful for streamers who want to change settings as they get this tab active as default.