### PR TITLE
Update zwift.proto

### DIFF
--- a/src/zwift.proto
+++ b/src/zwift.proto
@@ -663,7 +663,7 @@ message PlayerProfile {
     int64 curRideStreakTimestamp = 152;
     bool startedRunningTrialSubscription = 153;
     string publicId = 154;
-    float _f155 = 155; // Added 2025/01/30 (1.82+)
+    float totalWattHoursPerKg = 155;
 }
 
 message PlayerProfiles {


### PR DESCRIPTION
By comparing protobuf and JSON fields I found that `_f155` matches `totalWattHoursPerKg`. zwift-offline reached the same conclusion: https://github.com/zoffline/zwift-offline/blob/master/protobuf/profile.proto#L223C39-L223C61